### PR TITLE
exporting base and nodejs config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = {
+const base = {
   env: {
     es6: true,
     node: true,
@@ -246,3 +246,18 @@ module.exports = {
     "yield-star-spacing": "error"
   }
 };
+
+module.exports = {
+  base,
+  nodeJS: {...base, 
+    rules: {
+      "arrow-parens": ["error", "as-needed"],
+      "arrow-spacing": ['error', { before: true, after: true }],
+      "camelcase": 0,
+      "max-len": ["error", { "code": 120 }],
+      "max-nested-callbacks": 0,
+      "max-params": ["error", 4],
+      "no-magic-numbers": 0,
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox",
-  "version": "2.3.0",
+  "version": "3.1.0",
   "description": "ESLint configuration used by Wolox",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

# Warning: this breaks retrocompatibility 

- exposing different type of configs
- now projects should choose which configuration they like to use. This allows to make eslint changes for all the tech specific projects.