### PR TITLE
Fixed eslint error

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ module.exports = {
     "func-name-matching": "error",
     "func-names": "error",
     "id-length": ["error", { min: 1, max: 30 }],
-    "indent": ["error", 2, { SwitchCase: 1 }],
+    "indent": ["error", 2, { SwitchCase: 1, "ignoredNodes": ["ObjectExpression"] }],
     "jsx-quotes": ["error", "prefer-double"],
     "key-spacing": "error",
     "keyword-spacing": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "ESLint configuration used by Wolox",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

Let's look at this code:
```
const myfunction = () =>
  countThing().then(count =>
    count < 125
      ? createThing({
          auto_init: true,
          org: false
        })
      : Promise.reject('there was a problem')
  );
```
This code used to generate an error in Linter. But when trying to fix the error in Linter, it generated another error in Prettier. So there was a conflict between Linter and Prettier, and that conflict was fixed.

## Trello Card

https://trello.com/c/ZvIW7vlE/119-fix-linter-rules-que-se-contradicen-mutuamente
