### PR TITLE
eslint updated & no-extra-parens modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.0
+
+* ESLint version updated to ^6.4.0
+* `no-extra-parens` modified
+
 ## 3.0.0
 
 * Changelog added.

--- a/index.js
+++ b/index.js
@@ -49,15 +49,7 @@ module.exports = {
     "no-empty-character-class": "error",
     "no-ex-assign": "error",
     "no-extra-boolean-cast": "error",
-    "no-extra-parens": [
-      "error",
-      "all",
-      {
-        ignoreJSX: "all",
-        enforceForArrowConditionals: false,
-        returnAssign: false
-      }
-    ],
+    "no-extra-parens": ["error", "functions"],
     "no-extra-semi": "error",
     "no-func-assign": "error",
     "no-inner-declarations": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-wolox",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "ESLint configuration used by Wolox",
   "main": "index.js",
   "repository": {
@@ -12,11 +12,11 @@
     "url": "https://github.com/Wolox/eslint-config-wolox/issues"
   },
   "peerDependencies": {
-    "eslint": "5.9.0",
-    "prettier": "^1.15.3",
-    "prettier-eslint": "^8.8.2",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-import": "^2.17.3"
+    "eslint": "6.x",
+    "prettier": "1.x",
+    "prettier-eslint": "9.x",
+    "eslint-plugin-prettier": "3.x",
+    "eslint-plugin-import": "2.x"
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox#readme"
 }


### PR DESCRIPTION
## Summary

[Change!] Version uptated to 3.0.3
[Change!] ESLint updated to 6.4.0 or newer
[Change!] Changed `no-extra-parens` to apply only to `functions` to fix a conflict with a rule from prettier in the following case: 

```js
const newPlan = dataModified.planId && (await planService.findOneBy({ id: dataModified.planId }));
```

ESlint removes the paretheses but prettier then requires to add them.

## Trello Card

[Change!] https://trello.com/c/NyWrgZfZ/126-fix-linter-no-extra-parens
